### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/msondejsandpit/c1e29ed1-02d4-4405-aa64-b93116531728/26bec851-7ede-44ff-9e46-d3ed76415584/_apis/work/boardbadge/f554b5e0-7af0-4ab1-9d93-ccb862d11b4a)](https://dev.azure.com/msondejsandpit/c1e29ed1-02d4-4405-aa64-b93116531728/_boards/board/t/26bec851-7ede-44ff-9e46-d3ed76415584/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/XpiritBV/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.